### PR TITLE
現在の進捗

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
           VITE_POKEMON_TCG_USE_MOCK: ${{ secrets.VITE_POKEMON_TCG_USE_MOCK }}
         run: npm run build
 
+      - name: Copy 404.html for GitHub Pages SPA fallback
+        run: cp 404.html dist/
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/404.html
+++ b/404.html
@@ -6,21 +6,17 @@
     <title>PokéPack Opener</title>
     <script>
       // GitHub Pages用の404リダイレクト
+      // GitHub Pages プロジェクトサイト用（例: username.github.io/PokePackOpener/）
       var pathSegmentsToKeep = 1;
       var l = window.location;
+      var pathPrefix = l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/');
+      var clientPath = l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~');
+      // HashRouter 用に /#/ でリダイレクト（直接URLアクセス時の404回避）
       l.replace(
-        l.protocol +
-          '//' +
-          l.hostname +
-          (l.port ? ':' + l.port : '') +
-          l.pathname
-            .split('/')
-            .slice(0, 1 + pathSegmentsToKeep)
-            .join('/') +
-          '/?/' +
-          l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
-          (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
-          l.hash
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        pathPrefix + '/#/' + clientPath +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
       );
     </script>
   </head>


### PR DESCRIPTION
Fix 404 errors on GitHub Pages by deploying `404.html` and using the correct `HashRouter` redirect path.

---
<p><a href="https://cursor.com/agents?id=bc-15e05109-7736-4983-b741-72ccbb34ae39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15e05109-7736-4983-b741-72ccbb34ae39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

